### PR TITLE
Apply visiblity modifier fix

### DIFF
--- a/src/main/java/com/spikes2212/command/genericsubsystem/MotoredGenericSubsystem.java
+++ b/src/main/java/com/spikes2212/command/genericsubsystem/MotoredGenericSubsystem.java
@@ -60,7 +60,7 @@ public class MotoredGenericSubsystem extends GenericSubsystem {
     }
 
     @Override
-    public void apply(double speed) {
+    protected void apply(double speed) {
         motorControllerGroup.set(speed);
     }
 


### PR DESCRIPTION
apply() shouldn't be public, it should be used only on move() in the superclass GenericSubsystem (if it's public, you can change the speed without considering the canMove method or the maximum/minimum speed)