### PR TITLE
Fix ff calculation in MoveGenericSubsystemWithPID

### DIFF
--- a/src/main/java/com/spikes2212/command/genericsubsystem/commands/MoveGenericSubsystemWithPID.java
+++ b/src/main/java/com/spikes2212/command/genericsubsystem/commands/MoveGenericSubsystemWithPID.java
@@ -87,8 +87,8 @@ public class MoveGenericSubsystemWithPID extends CommandBase {
     public void execute() {
         pidController.setTolerance(pidSettings.getTolerance());
         pidController.setPID(pidSettings.getkP(), pidSettings.getkI(), pidSettings.getkD());
-        feedForwardController.setGains(feedForwardSettings.getkS(), feedForwardController.getkV(),
-                feedForwardController.getkA(), feedForwardController.getkG());
+        feedForwardController.setGains(feedForwardSettings.getkS(), feedForwardSettings.getkV(),
+                feedForwardSettings.getkA(), feedForwardSettings.getkG());
 
         double pidValue = pidController.calculate(source.get(), setpoint.get());
         double svagValue = feedForwardController.calculate(setpoint.get());


### PR DESCRIPTION
the ff controller in MoveGenericSubsystemWithPID was constantly updated with the gains from itself, not feedForwardSettings. so i fixed that