### PR TITLE
updated libraries, removed requirement for non-empty MotorControllerG…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,15 +36,15 @@ publishing {
 }
 
 dependencies {
-    implementation group: 'com.ctre.phoenix6', name: 'wpiapi-java', version: '24.0.0-beta-8'
-    implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-java', version: '2024.1.1'
-    implementation group: 'edu.wpi.first.wpilibNewCommands', name: 'wpilibNewCommands-java', version: '2024.1.1'
-    implementation group: 'edu.wpi.first.wpilibj', name: 'wpilibj-java', version: '2024.1.1'
-    implementation group: 'edu.wpi.first.cameraserver', name: 'cameraserver-java', version: '2024.1.1'
-    implementation group: 'edu.wpi.first.wpiutil', name: 'wpiutil-java', version: '2024.1.1'
-    implementation group: 'edu.wpi.first.wpimath', name: 'wpimath-java', version: '2024.1.1'
-    implementation group: 'edu.wpi.first.wpiunits', name: 'wpiunits-java', version: '2024.1.1'
+    implementation group: 'com.ctre.phoenix6', name: 'wpiapi-java', version: '24.1.0'
+    implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-java', version: '2024.2.1'
+    implementation group: 'edu.wpi.first.wpilibNewCommands', name: 'wpilibNewCommands-java', version: '2024.2.1'
+    implementation group: 'edu.wpi.first.wpilibj', name: 'wpilibj-java', version: '2024.2.1'
+    implementation group: 'edu.wpi.first.cameraserver', name: 'cameraserver-java', version: '2024.2.1'
+    implementation group: 'edu.wpi.first.wpiutil', name: 'wpiutil-java', version: '2024.2.1'
+    implementation group: 'edu.wpi.first.wpimath', name: 'wpimath-java', version: '2024.2.1'
+    implementation group: 'edu.wpi.first.wpiunits', name: 'wpiunits-java', version: '2024.2.1'
     implementation group: 'com.revrobotics.frc', name: 'REVLib-java', version: '2024.2.0'
-    implementation group: 'com.ctre.phoenix', name: 'api-java', version: '5.32.0-beta-5'
-    implementation group: 'com.ctre.phoenix', name: 'wpiapi-java', version: '5.31.0'
+    implementation group: 'com.ctre.phoenix', name: 'api-java', version: '5.33.0'
+    implementation group: 'com.ctre.phoenix', name: 'wpiapi-java', version: '5.33.0'
 }

--- a/src/main/java/com/spikes2212/util/BustedMotorControllerGroup.java
+++ b/src/main/java/com/spikes2212/util/BustedMotorControllerGroup.java
@@ -1,7 +1,6 @@
 package com.spikes2212.util;
 
 import edu.wpi.first.wpilibj.motorcontrol.MotorController;
-import edu.wpi.first.wpilibj.motorcontrol.MotorControllerGroup;
 
 import java.util.function.Supplier;
 
@@ -18,13 +17,13 @@ public class BustedMotorControllerGroup extends MotorControllerGroup {
      */
     protected final Supplier<Double> correction;
 
-    public BustedMotorControllerGroup(Supplier<Double> correction, MotorController motorController, MotorController... motorControllers) {
-        super(motorController, motorControllers);
+    public BustedMotorControllerGroup(Supplier<Double> correction, MotorController... motorControllers) {
+        super(motorControllers);
         this.correction = correction;
     }
 
-    public BustedMotorControllerGroup(double correction, MotorController motorController, MotorController... motorControllers) {
-        this(() -> correction, motorController, motorControllers);
+    public BustedMotorControllerGroup(double correction, MotorController... motorControllers) {
+        this(() -> correction, motorControllers);
     }
 
     @Override

--- a/src/main/java/com/spikes2212/util/MotorControllerGroup.java
+++ b/src/main/java/com/spikes2212/util/MotorControllerGroup.java
@@ -5,11 +5,12 @@ import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.motorcontrol.MotorController;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class MotorControllerGroup implements MotorController, Sendable, AutoCloseable {
 
-    private final List<MotorController> motorControllers;
+    private final List<? extends MotorController> motorControllers;
     private boolean inverted;
 
     public MotorControllerGroup(MotorController... motorControllers) {

--- a/src/main/java/com/spikes2212/util/MotorControllerGroup.java
+++ b/src/main/java/com/spikes2212/util/MotorControllerGroup.java
@@ -5,7 +5,6 @@ import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.motorcontrol.MotorController;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class MotorControllerGroup implements MotorController, Sendable, AutoCloseable {


### PR DESCRIPTION
…roup and made BustedMotorControllerGroup use undeprecated MotorControllerGroup